### PR TITLE
fix: starting drag although the board is already focused state.

### DIFF
--- a/lib/feature/guest_game/view_model/guest_game_view_model.dart
+++ b/lib/feature/guest_game/view_model/guest_game_view_model.dart
@@ -344,6 +344,32 @@ class GuestGameViewModel extends BaseCubit<GuestGameState> {
       ),
     ));
 
+    // after first build set canMove to false for all squares to prevent to
+    // start a drag from a square that is not rendered at first build.
+    Future.microtask(() {
+      G.logger.t('GuestGameViewModel._emitFocus.microTask: Setting canMove to '
+          'false for all squares');
+
+      for (final e in _squareStates.entries) {
+        if (e.value.canMove == false) continue;
+
+        _squareStates[e.key] = e.value.copyWith(canMove: false);
+      }
+
+      emit(state.copyWith(
+        gameState: gameState.copyWith(
+          squareStates: _squareStates,
+          isFocused: true,
+          turnStatus: turnStatus,
+          canUndo: chessService.canUndo(),
+          canRedo: chessService.canRedo(),
+        ),
+      ));
+
+      G.logger.t('GuestGameViewModel._emitFocus.microTask: '
+          'canMove set to false for all squares');
+    });
+
     G.logger.t('GuestGameViewModel._emitFocus: Focused on $focusedCoordinate');
   }
 

--- a/lib/feature/host_game/view_model/host_game_view_model.dart
+++ b/lib/feature/host_game/view_model/host_game_view_model.dart
@@ -332,6 +332,33 @@ class HostGameViewModel extends BaseCubit<HostGameState> {
       ),
     ));
 
+    // after first build set canMove to false for all squares to prevent to
+    // start a drag from a square that is not rendered at first build.
+    Future.microtask(() {
+      G.logger.t('HostGameViewModel._emitFocus.microTask:'
+          ' Setting canMove to false');
+
+      for (final e in _squareStates.entries) {
+        if (e.value.canMove == false) continue;
+
+        _squareStates[e.key] = e.value.copyWith(canMove: false);
+      }
+
+      final state = this.state;
+      emit((state as HostGameLoadedState).copyWith(
+        gameState: state.gameState.copyWith(
+          squareStates: _squareStates,
+          isFocused: true,
+          turnStatus: turnStatus,
+          canUndo: _chessService.canUndo(),
+          canRedo: _chessService.canRedo(),
+        ),
+      ));
+
+      G.logger.t('HostGameViewModel._emitFocus.microTask:'
+          ' Completely emitted');
+    });
+
     G.logger.t('HostGameViewModel._emitFocus: Focused on $focusedCoordinate');
   }
 

--- a/lib/feature/local_game/view_model/local_game_view_model.dart
+++ b/lib/feature/local_game/view_model/local_game_view_model.dart
@@ -97,6 +97,31 @@ class LocalGameViewModel extends BaseCubit<LocalGameState> {
       canRedo: _chessService.canRedo(),
     ));
 
+    // after first build set canMove to false for all squares to prevent to
+    // start a drag from a square that is not rendered at first build.
+    Future.microtask(() {
+      G.logger.t('LocalGameViewModel._emitFocus.microTask: Setting canMove to '
+          'false for all squares');
+
+      for (final e in _squareStates.entries) {
+        if (e.value.canMove == false) continue;
+
+        _squareStates[e.key] = e.value.copyWith(canMove: false);
+      }
+
+      emit(LocalGameLoadedState(
+        squareStates: _squareStates,
+        isFocused: true,
+        turnStatus: turnStatus,
+        capturedPieces: (state as LocalGameLoadedState).capturedPieces,
+        canUndo: _chessService.canUndo(),
+        canRedo: _chessService.canRedo(),
+      ));
+
+      G.logger.t('LocalGameViewModel._emitFocus.microTask:'
+          ' Set canMove to false for all squares');
+    });
+
     G.logger.t('LocalGameViewModel._emitStateWhenFocus:'
         ' Focused on $focusedCoordinate');
   }

--- a/lib/product/data/square_data.dart
+++ b/lib/product/data/square_data.dart
@@ -69,6 +69,32 @@ class SquareData extends Equatable {
   /// Whether the piece can be captured in this square.
   bool get canCaptured => captureToThis != null;
 
+  /// Creates a copy of this object with the given fields replaced by the new
+  /// values.
+  SquareData copyWith({
+    AppPiece? piece,
+    bool? canMove,
+    bool? isThisCheck,
+    bool? isLastMoveFromThis,
+    bool? isLastMoveToThis,
+    bool? isFocusedOnThis,
+    bool? isSyncInProcess,
+    AppChessMove? moveToThis,
+    AppChessMove? captureToThis,
+  }) {
+    return SquareData(
+      piece: piece ?? this.piece,
+      canMove: canMove ?? this.canMove,
+      isThisCheck: isThisCheck ?? this.isThisCheck,
+      isLastMoveFromThis: isLastMoveFromThis ?? this.isLastMoveFromThis,
+      isLastMoveToThis: isLastMoveToThis ?? this.isLastMoveToThis,
+      isFocusedOnThis: isFocusedOnThis ?? this.isFocusedOnThis,
+      isSyncInProcess: isSyncInProcess ?? this.isSyncInProcess,
+      moveToThis: moveToThis ?? this.moveToThis,
+      captureToThis: captureToThis ?? this.captureToThis,
+    );
+  }
+
   @override
   List<Object?> get props => [
         piece,


### PR DESCRIPTION
* All game screens are rebuilds all the squares marked as 'canMove' after emit the focused state. (this step is done in microtask)